### PR TITLE
Removed dynamic allocations and added some related improvements

### DIFF
--- a/src/Tests/Tests.Dybal.Utils.Guards.ObjectExtensions/GuardObjectExtensionTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards.ObjectExtensions/GuardObjectExtensionTests.cs
@@ -29,7 +29,7 @@ public class GuardObjectExtensionTests
         var guard = value.Guard();
 
         // Assert
-        Assert.Equal(nameof(value), guard.ArgumentName);
+        Assert.Equal(nameof(value), guard.Argument.Name);
     }
 
     [Fact]
@@ -42,6 +42,6 @@ public class GuardObjectExtensionTests
         var guard = value.Guard();
 
         // Assert
-        Assert.Equal(value, guard.ArgumentValue);
+        Assert.Equal(value, guard.Argument.Value);
     }
 }

--- a/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/ArgumentTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/ArgumentTests.cs
@@ -28,7 +28,7 @@ public class ArgumentTests : UnitTestsBase
         var guard = Guard.Argument(value);
 
         // Assert
-        Assert.Equal(nameof(value), guard.ArgumentName);
+        Assert.Equal(nameof(value), guard.Argument.Name);
     }
 
     [Fact]
@@ -41,6 +41,6 @@ public class ArgumentTests : UnitTestsBase
         var guard = Guard.Argument(value);
 
         // Assert
-        Assert.Equal(value, guard.ArgumentValue);
+        Assert.Equal(value, guard.Argument.Value);
     }
 }

--- a/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/ContainTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/ContainTests.cs
@@ -58,7 +58,7 @@ public class ContainTests : UnitTestsBase
 
         void Act()
         {
-            Guard.Argument(source).Contain(_ => false);
+            Guard.Argument(source).Contain(static _ => false);
         }
 
         // Assert

--- a/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/IfHasValueTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/IfHasValueTests.cs
@@ -41,7 +41,7 @@ public class IfHasValueTests : UnitTestsBase
         var guard = Guard.Argument(value).IfHasValue();
 
         // Assert
-        Assert.Equal(nameof(value), guard.ArgumentName);
+        Assert.Equal(nameof(value), guard.Argument.Name);
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class IfHasValueTests : UnitTestsBase
         var guard = Guard.Argument(value).IfHasValue();
 
         // Assert
-        Assert.Equal(value, guard.ArgumentValue);
+        Assert.Equal(value, guard.Argument.Value);
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class IfHasValueTests : UnitTestsBase
         var guard = Guard.Argument(value).IfHasValue();
 
         // Assert
-        Assert.Equal(nameof(value), guard.ArgumentName);
+        Assert.Equal(nameof(value), guard.Argument.Name);
     }
 
     [Fact]
@@ -80,6 +80,6 @@ public class IfHasValueTests : UnitTestsBase
         var guard = Guard.Argument(value).IfHasValue();
 
         // Assert
-        Assert.Equal(value, guard.ArgumentValue);
+        Assert.Equal(value, guard.Argument.Value);
     }
 }

--- a/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/IfTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/IfTests.cs
@@ -41,7 +41,7 @@ public class IfTests : UnitTestsBase
         var guard = Guard.Argument(value).If(true);
 
         // Assert
-        AssertGuard.AssertArgument(value, guard.ArgumentValue, guard.ArgumentName);
+        AssertGuard.AssertArgument(value, guard.Argument.Value, guard.Argument.Name);
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class IfTests : UnitTestsBase
         var guard = Guard.Argument(value).If(false);
 
         // Assert
-        AssertGuard.AssertArgument(value, guard.ArgumentValue, guard.ArgumentName);
+        AssertGuard.AssertArgument(value, guard.Argument.Value, guard.Argument.Name);
     }
 
     [Fact]

--- a/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/NotNullTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/NotNullTests.cs
@@ -93,6 +93,23 @@ public class NotNullTests : UnitTestsBase
     }
 
     [Fact]
+    public void ShouldThrows_ArgumentNullExceptionWithCustomMessage_When_PropertyWithoutValue()
+    {
+        // Arrange
+        var customMessage = "Custom message";
+        var sample = new { Value = (object?)null };
+
+        void Act()
+        {
+            Guard.Argument(sample.Value).NotNull(customMessage);
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentNullException>(Act);
+        Assert.Equal($"{customMessage} (Parameter 'sample.Value')", ex.Message);
+    }
+
+    [Fact]
     public void Should_NotThrows_When_GuardIsNotActive()
     {
         // Arrange
@@ -141,7 +158,7 @@ public class NotNullTests : UnitTestsBase
     {
         // Arrange
         object? nullableValue = null;
-        
+
         void Act()
         {
             object value = Guard.Argument(nullableValue).NotNull();

--- a/src/Tests/Tests.Dybal.Utils.Guards/AssertGuard.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/AssertGuard.cs
@@ -6,7 +6,7 @@ namespace Tests.Dybal.Utils.Guards;
 
 public class AssertGuard
 {
-    public static void AssertArgument<T>(T value, Argument<object?> argument, [CallerArgumentExpression("value")] string? valueName = null)
+    public static void AssertArgument<T>(T value, IArgument<object?> argument, [CallerArgumentExpression("value")] string? valueName = null)
     {
         AssertArgument(value, argument.Value, argument.Name, valueName);
     }

--- a/src/Tests/Tests.Dybal.Utils.Guards/GuardProviderTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/GuardProviderTests.cs
@@ -29,7 +29,7 @@ public class GuardProviderTests : UnitTestsBase
         var guard = Guard(value);
 
         // Assert
-        Assert.Equal(nameof(value), guard.ArgumentName);
+        Assert.Equal(nameof(value), guard.Argument.Name);
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class GuardProviderTests : UnitTestsBase
         var guard = Guard(value);
 
         // Assert
-        Assert.Equal(value, guard.ArgumentValue);
+        Assert.Equal(value, guard.Argument.Value);
     }
 
 

--- a/src/Utils/Dybal.Utils.Guards/Argument.cs
+++ b/src/Utils/Dybal.Utils.Guards/Argument.cs
@@ -1,3 +1,7 @@
 ﻿namespace Dybal.Utils.Guards;
 
-public record struct Argument<TArgument>(TArgument Value, string Name);
+public readonly record struct Argument<TArgument>(TArgument Value, string Name)
+{
+    public TArgument Value { get; } = Value;
+    public string Name { get; } = Name;
+}

--- a/src/Utils/Dybal.Utils.Guards/Argument.cs
+++ b/src/Utils/Dybal.Utils.Guards/Argument.cs
@@ -1,3 +1,3 @@
 ﻿namespace Dybal.Utils.Guards;
 
-public record Argument<TArgument>(TArgument Value, string Name);
+public record struct Argument<TArgument>(TArgument Value, string Name);

--- a/src/Utils/Dybal.Utils.Guards/Argument.cs
+++ b/src/Utils/Dybal.Utils.Guards/Argument.cs
@@ -1,6 +1,6 @@
 ﻿namespace Dybal.Utils.Guards;
 
-public readonly record struct Argument<TArgument>(TArgument Value, string Name)
+public readonly record struct Argument<TArgument>(TArgument Value, string Name) : IArgument<TArgument>
 {
     public TArgument Value { get; } = Value;
     public string Name { get; } = Name;

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuard.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuard.cs
@@ -5,9 +5,9 @@ internal record struct ArgumentGuard<TArgument> : IArgumentGuard<TArgument>, ICo
     public bool IsActive { get; private set; }
     public IArgument<TArgument> Argument { get; }
 
-    internal ArgumentGuard(TArgument argumentValue, string argumentName, bool isActive)
+    internal ArgumentGuard(IArgument<TArgument> argument, bool isActive)
     {
-        Argument = new Argument<TArgument>(argumentValue, argumentName);
+        Argument = argument;
         IsActive = isActive;
     }
     

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuard.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuard.cs
@@ -3,13 +3,11 @@
 internal record struct ArgumentGuard<TArgument> : IArgumentGuard<TArgument>, IConditionalArgumentGuard<TArgument>
 {
     public bool IsActive { get; private set; }
-    public TArgument ArgumentValue { get; }
-    public string ArgumentName { get; }
+    public IArgument<TArgument> Argument { get; }
 
     internal ArgumentGuard(TArgument argumentValue, string argumentName, bool isActive)
     {
-        ArgumentValue = argumentValue;
-        ArgumentName = argumentName;
+        Argument = new Argument<TArgument>(argumentValue, argumentName);
         IsActive = isActive;
     }
     

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Contain.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Contain.cs
@@ -13,12 +13,12 @@ public static partial class ArgumentGuardExtensions
     {
         if (guard.IsActive)
         {
-            if (!guard.ArgumentValue.Any(filter))
+            if (!guard.Argument.Value.Any(filter))
             {
-                ThrowHelper.ThrowArgumentException(message ?? "Collection does not contain required item.", guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? "Collection does not contain required item.", guard.Argument.Name);
             }
         }
 
-        return guard.ArgumentValue;
+        return guard.Argument.Value;
     }
 }

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Contain.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Contain.cs
@@ -15,7 +15,7 @@ public static partial class ArgumentGuardExtensions
         {
             if (!guard.ArgumentValue.Any(filter))
             {
-                throw new ArgumentException(message ?? "Collection does not contain required item.", guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? "Collection does not contain required item.", guard.ArgumentName);
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Contain.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Contain.cs
@@ -15,7 +15,7 @@ public static partial class ArgumentGuardExtensions
         {
             if (!guard.Argument.Value.Any(filter))
             {
-                ThrowHelper.ThrowArgumentException(message ?? "Collection does not contain required item.", guard.Argument.Name);
+                ThrowHelper.Throw<ArgumentException>(guard.Argument.Name, message ?? "Collection does not contain required item.");
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.ContainNotNull.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.ContainNotNull.cs
@@ -6,6 +6,6 @@ public static partial class ArgumentGuardExtensions
 {
     public static IEnumerable<TArgument> ContainNotNull<TArgument>(this IArgumentGuard<IEnumerable<TArgument>> guard, string? message = null)
     {
-        return guard.Contain(item => item is not null, message ?? "Collection has to contain an item with not default value.");
+        return guard.Contain(static item => item is not null, message ?? "Collection has to contain an item with not default value.");
     }
 }

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.ContainNull.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.ContainNull.cs
@@ -6,6 +6,6 @@ public static partial class ArgumentGuardExtensions
 {
     public static IEnumerable<TArgument> ContainNull<TArgument>(this IArgumentGuard<IEnumerable<TArgument>> guard, string? message = null)
     {
-        return guard.Contain(item => item is null, message ?? "Collection has to contain null.");
+        return guard.Contain(static item => item is null, message ?? "Collection has to contain null.");
     }
 }

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Default.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Default.cs
@@ -12,7 +12,7 @@ public static partial class ArgumentGuardExtensions
                 var defaultMessage = guard.Argument.Value is Guid ? 
                                         "Value must be an empty GUID." : 
                                         "Value must be a default value.";
-                ThrowHelper.ThrowArgumentException(message ?? defaultMessage, guard.Argument.Name);
+                ThrowHelper.Throw<ArgumentException>(guard.Argument.Name, message ?? defaultMessage);
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Default.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Default.cs
@@ -12,7 +12,7 @@ public static partial class ArgumentGuardExtensions
                 var defaultMessage = guard.ArgumentValue is Guid ? 
                                         "Value must be an empty GUID." : 
                                         "Value must be a default value.";
-                throw new ArgumentException(message ?? defaultMessage, guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? defaultMessage, guard.ArgumentName);
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Default.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Default.cs
@@ -7,15 +7,15 @@ public static partial class ArgumentGuardExtensions
     {
         if (guard.IsActive)
         {
-            if (!guard.ArgumentValue.Equals(default(TArgument)))
+            if (!guard.Argument.Value.Equals(default(TArgument)))
             {
-                var defaultMessage = guard.ArgumentValue is Guid ? 
+                var defaultMessage = guard.Argument.Value is Guid ? 
                                         "Value must be an empty GUID." : 
                                         "Value must be a default value.";
-                ThrowHelper.ThrowArgumentException(message ?? defaultMessage, guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? defaultMessage, guard.Argument.Name);
             }
         }
 
-        return guard.ArgumentValue;
+        return guard.Argument.Value;
     }
 }

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.IfHasValue.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.IfHasValue.cs
@@ -5,6 +5,6 @@ public static partial class ArgumentGuardExtensions
     public static IArgumentGuard<TArgument?> IfHasValue<TArgument>(this IArgumentGuard<TArgument?> guard)
         where TArgument : struct
     {
-        return guard.If(guard.ArgumentValue.HasValue);
+        return guard.If(guard.Argument.Value.HasValue);
     }
 }

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.IsNullOrEmpty.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.IsNullOrEmpty.cs
@@ -10,7 +10,7 @@ public static partial class ArgumentGuardExtensions
         {
             if (string.IsNullOrEmpty(guard.ArgumentValue))
             {
-                throw new ArgumentException(message ?? "Value cannot be null or empty string.", guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? "Value cannot be null or empty string.", guard.ArgumentName);
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.IsNullOrEmpty.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.IsNullOrEmpty.cs
@@ -8,12 +8,12 @@ public static partial class ArgumentGuardExtensions
     {
         if (guard.IsActive)
         {
-            if (string.IsNullOrEmpty(guard.ArgumentValue))
+            if (string.IsNullOrEmpty(guard.Argument.Value))
             {
-                ThrowHelper.ThrowArgumentException(message ?? "Value cannot be null or empty string.", guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? "Value cannot be null or empty string.", guard.Argument.Name);
             }
         }
 
-        return guard.ArgumentValue!;
+        return guard.Argument.Value!;
     }
 }

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.IsNullOrEmpty.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.IsNullOrEmpty.cs
@@ -10,7 +10,7 @@ public static partial class ArgumentGuardExtensions
         {
             if (string.IsNullOrEmpty(guard.Argument.Value))
             {
-                ThrowHelper.ThrowArgumentException(message ?? "Value cannot be null or empty string.", guard.Argument.Name);
+                ThrowHelper.Throw<ArgumentException>(guard.Argument.Name, message ?? "Value cannot be null or empty string.");
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNull.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNull.cs
@@ -13,9 +13,6 @@ public static partial class ArgumentGuardExtensions
         {
             if (guard.ArgumentValue is null)
             {
-                if (message == null)
-                    ThrowHelper.ThrowArgumentNullException(guard.ArgumentName);
-
                 ThrowHelper.ThrowArgumentNullException(guard.ArgumentName, message);
             }
         }

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNull.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNull.cs
@@ -13,7 +13,7 @@ public static partial class ArgumentGuardExtensions
         {
             if (guard.Argument.Value is null)
             {
-                ThrowHelper.ThrowArgumentNullException(guard.Argument.Name, message);
+                ThrowHelper.Throw<ArgumentNullException>(guard.Argument.Name, message);
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNull.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNull.cs
@@ -13,9 +13,10 @@ public static partial class ArgumentGuardExtensions
         {
             if (guard.ArgumentValue is null)
             {
-                throw message == null
-                    ? new ArgumentNullException(guard.ArgumentName)
-                    : new ArgumentNullException(guard.ArgumentName, message);
+                if (message == null)
+                    ThrowHelper.ThrowArgumentNullException(guard.ArgumentName);
+
+                ThrowHelper.ThrowArgumentNullException(guard.ArgumentName, message);
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNull.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNull.cs
@@ -11,12 +11,12 @@ public static partial class ArgumentGuardExtensions
     {
         if (guard.IsActive)
         {
-            if (guard.ArgumentValue is null)
+            if (guard.Argument.Value is null)
             {
-                ThrowHelper.ThrowArgumentNullException(guard.ArgumentName, message);
+                ThrowHelper.ThrowArgumentNullException(guard.Argument.Name, message);
             }
         }
 
-        return guard.ArgumentValue!;
+        return guard.Argument.Value!;
     }
 }

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNullOrWhiteSpace.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNullOrWhiteSpace.cs
@@ -10,7 +10,7 @@ public static partial class ArgumentGuardExtensions
         {
             if (string.IsNullOrWhiteSpace(guard.ArgumentValue))
             {
-                throw new ArgumentException(message ?? "Value cannot be null or white space string.", guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? "Value cannot be null or white space string.", guard.ArgumentName);
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNullOrWhiteSpace.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNullOrWhiteSpace.cs
@@ -8,12 +8,12 @@ public static partial class ArgumentGuardExtensions
     {
         if (guard.IsActive)
         {
-            if (string.IsNullOrWhiteSpace(guard.ArgumentValue))
+            if (string.IsNullOrWhiteSpace(guard.Argument.Value))
             {
-                ThrowHelper.ThrowArgumentException(message ?? "Value cannot be null or white space string.", guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? "Value cannot be null or white space string.", guard.Argument.Name);
             }
         }
 
-        return guard.ArgumentValue!;
+        return guard.Argument.Value!;
     }
 }

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNullOrWhiteSpace.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.NotNullOrWhiteSpace.cs
@@ -10,7 +10,7 @@ public static partial class ArgumentGuardExtensions
         {
             if (string.IsNullOrWhiteSpace(guard.Argument.Value))
             {
-                ThrowHelper.ThrowArgumentException(message ?? "Value cannot be null or white space string.", guard.Argument.Name);
+                ThrowHelper.Throw<ArgumentException>(guard.Argument.Name, message ?? "Value cannot be null or white space string.");
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Null.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Null.cs
@@ -8,7 +8,7 @@ public static partial class ArgumentGuardExtensions
         {
             if (guard.ArgumentValue is not null)
             {
-                throw new ArgumentException(message ?? "Value must be null.", guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? "Value must be null.", guard.ArgumentName);
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Null.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Null.cs
@@ -8,7 +8,7 @@ public static partial class ArgumentGuardExtensions
         {
             if (guard.Argument.Value is not null)
             {
-                ThrowHelper.ThrowArgumentException(message ?? "Value must be null.", guard.Argument.Name);
+                ThrowHelper.Throw<ArgumentException>(guard.Argument.Name, message ?? "Value must be null.");
             }
         }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Null.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.Null.cs
@@ -6,12 +6,12 @@ public static partial class ArgumentGuardExtensions
     {
         if (guard.IsActive)
         {
-            if (guard.ArgumentValue is not null)
+            if (guard.Argument.Value is not null)
             {
-                ThrowHelper.ThrowArgumentException(message ?? "Value must be null.", guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? "Value must be null.", guard.Argument.Name);
             }
         }
 
-        return guard.ArgumentValue;
+        return guard.Argument.Value;
     }
 }

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensionsNotDefault.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensionsNotDefault.cs
@@ -11,7 +11,7 @@ public static partial class ArgumentGuardExtensions
                 var defaultMessage = guard.Argument.Value is Guid ?
                                         "Value cannot be an empty GUID." :
                                         "Value cannot be the default value.";
-                ThrowHelper.ThrowArgumentException(message ?? defaultMessage, guard.Argument.Name);
+                ThrowHelper.Throw<ArgumentException>(guard.Argument.Name, message ?? defaultMessage);
             }
         }
 
@@ -28,7 +28,8 @@ public static partial class ArgumentGuardExtensions
                 return Guard.Argument(guard.Argument.Value.Value, guard.Argument.Name).NotDefault();
             }
 
-            ThrowHelper.ThrowArgumentException(message ?? "Nullable object must have a value.", guard.Argument.Name);
+            string message1 = message ?? "Nullable object must have a value.";
+            ThrowHelper.Throw<ArgumentException>(guard.Argument.Name, message1);
         }
 
         return guard.Argument.Value;

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensionsNotDefault.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensionsNotDefault.cs
@@ -11,7 +11,7 @@ public static partial class ArgumentGuardExtensions
                 var defaultMessage = guard.ArgumentValue is Guid ?
                                         "Value cannot be an empty GUID." :
                                         "Value cannot be the default value.";
-                throw new ArgumentException(message ?? defaultMessage, guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? defaultMessage, guard.ArgumentName);
             }
         }
 
@@ -28,7 +28,7 @@ public static partial class ArgumentGuardExtensions
                 return Guard.Argument(guard.ArgumentValue.Value, guard.ArgumentName).NotDefault();
             }
 
-            throw new ArgumentException(message ?? "Nullable object must have a value.", guard.ArgumentName);
+            ThrowHelper.ThrowArgumentException(message ?? "Nullable object must have a value.", guard.ArgumentName);
         }
 
         return guard.ArgumentValue;

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensionsNotDefault.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensionsNotDefault.cs
@@ -6,16 +6,16 @@ public static partial class ArgumentGuardExtensions
     {
         if (guard.IsActive)
         {
-            if (EqualityComparer<TArgument>.Default.Equals(guard.ArgumentValue, default))
+            if (EqualityComparer<TArgument>.Default.Equals(guard.Argument.Value, default))
             {
-                var defaultMessage = guard.ArgumentValue is Guid ?
+                var defaultMessage = guard.Argument.Value is Guid ?
                                         "Value cannot be an empty GUID." :
                                         "Value cannot be the default value.";
-                ThrowHelper.ThrowArgumentException(message ?? defaultMessage, guard.ArgumentName);
+                ThrowHelper.ThrowArgumentException(message ?? defaultMessage, guard.Argument.Name);
             }
         }
 
-        return guard.ArgumentValue;
+        return guard.Argument.Value;
     }
 
     public static TArgument? NotDefault<TArgument>(this IArgumentGuard<TArgument?> guard, string? message = null)
@@ -23,14 +23,14 @@ public static partial class ArgumentGuardExtensions
     {
         if (guard.IsActive)
         {
-            if (guard.ArgumentValue.HasValue)
+            if (guard.Argument.Value.HasValue)
             {
-                return Guard.Argument(guard.ArgumentValue.Value, guard.ArgumentName).NotDefault();
+                return Guard.Argument(guard.Argument.Value.Value, guard.Argument.Name).NotDefault();
             }
 
-            ThrowHelper.ThrowArgumentException(message ?? "Nullable object must have a value.", guard.ArgumentName);
+            ThrowHelper.ThrowArgumentException(message ?? "Nullable object must have a value.", guard.Argument.Name);
         }
 
-        return guard.ArgumentValue;
+        return guard.Argument.Value;
     }
 }

--- a/src/Utils/Dybal.Utils.Guards/CompactList.cs
+++ b/src/Utils/Dybal.Utils.Guards/CompactList.cs
@@ -7,7 +7,7 @@ namespace Dybal.Utils.Guards
     /// Custom List implementation that does not make any dynamic allocation if Count <= 3
     /// </summary>
     /// <typeparam name="TElement"></typeparam>
-    public struct CompactList<TElement> : IReadOnlyList<TElement?>
+    public readonly struct CompactList<TElement> : IReadOnlyList<TElement?>
     {
         private readonly TElement? firstElement = default;
         private readonly TElement? secondElement = default;

--- a/src/Utils/Dybal.Utils.Guards/CompactList.cs
+++ b/src/Utils/Dybal.Utils.Guards/CompactList.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 
 namespace Dybal.Utils.Guards
 {
@@ -6,20 +7,39 @@ namespace Dybal.Utils.Guards
     /// Custom List implementation that does not make any dynamic allocation if Count <= 3
     /// </summary>
     /// <typeparam name="TElement"></typeparam>
-    public struct CompactList<TElement> : IList<TElement?>
+    public struct CompactList<TElement> : IReadOnlyList<TElement?>
     {
-        private TElement? firstElement;
-        private TElement? secondElement;
-        private TElement? thirdElement;
-        private List<TElement?>? otherElements;
-        private int count;
+        private readonly TElement? firstElement = default;
+        private readonly TElement? secondElement = default;
+        private readonly TElement? thirdElement = default;
+        private readonly TElement?[]? otherElements = default;
 
+        public CompactList(TElement? firstElement, TElement? secondElement)
+        {
+            this.firstElement = firstElement;
+            this.secondElement = secondElement;
+            Count = 2;
+        }
+
+        public CompactList(TElement? firstElement, TElement? secondElement, TElement? thirdElement, params TElement?[] otherElements)
+            : this(firstElement, secondElement)
+        {
+            this.firstElement = firstElement;
+            this.secondElement = secondElement;
+            this.thirdElement = thirdElement;
+            this.otherElements = otherElements;
+
+            Count = 3 + otherElements.Length;
+        }
+        
         public TElement? this[int index]
         {
             get
             {
-                if (index < 0 || index >= count)
+                if (index < 0 || index >= Count)
+                {
                     ThrowHelper.ThrowArgumentException("Provided index was outside of the valid range.", nameof(index));
+                }
 
                 return index switch
                 {
@@ -29,95 +49,14 @@ namespace Dybal.Utils.Guards
                     _ => otherElements![index - 3],
                 };
             }
-            set
-            {
-                if (index < 0 || index >= count)
-                    ThrowHelper.ThrowArgumentException("Provided index was outside of the valid range.", nameof(index));
-
-                switch (index)
-                {
-                    case 0: firstElement = value; break;
-                    case 1: secondElement = value; break;
-                    case 2: thirdElement = value; break;
-                    default: otherElements![index] = value; break;
-                }
-            }
         }
 
-        public int Count { get { return count; } set { count = value; } }
-        public bool IsReadOnly => false;
-
-        public void Add(TElement? item)
-        {
-            if (count <= 2)
-            {
-                switch (count)
-                {
-                    case 0: firstElement = item; break;
-                    case 1: secondElement = item; break;
-                    case 2: thirdElement = item; break;
-                }
-            }
-            else
-            {
-                otherElements ??= new List<TElement?>();
-                otherElements.Add(item);
-            }
-
-            count++;
-        }
-
-        public void Clear()
-        {
-            firstElement = default;
-            secondElement = default;
-            thirdElement = default;
-            otherElements?.Clear();
-        }
-
-        public bool Contains(TElement? item)
-        {
-            return IndexOf(item) != -1;
-        }
-
-        public void CopyTo(TElement?[] array, int arrayIndex)
-        {
-            throw new NotImplementedException();
-        }
+        public int Count { get; }
 
         public IEnumerator<TElement?> GetEnumerator()
         {
-            for (var index = 0; index < count; index++)
+            for (var index = 0; index < Count; index++)
                 yield return this[index];
-        }
-
-        public int IndexOf(TElement? item)
-        {
-            if (item == null)
-                return -1;
-
-            for (var index = 0; index < count; index++)
-            {
-                if (item.Equals(this[index]))
-                    return index;
-            }
-
-            return -1;
-        }
-
-        public void Insert(int index, TElement? item)
-        {
-            throw new NotImplementedException();
-        }
-
-        public bool Remove(TElement? item)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void RemoveAt(int index)
-        {
-            throw new NotImplementedException();
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/Utils/Dybal.Utils.Guards/CompactList.cs
+++ b/src/Utils/Dybal.Utils.Guards/CompactList.cs
@@ -38,7 +38,7 @@ namespace Dybal.Utils.Guards
             {
                 if (index < 0 || index >= Count)
                 {
-                    ThrowHelper.ThrowArgumentException("Provided index was outside of the valid range.", nameof(index));
+                    ThrowHelper.Throw<ArgumentException>(nameof(index), "Provided index was outside of the valid range.");
                 }
 
                 return index switch

--- a/src/Utils/Dybal.Utils.Guards/CompactList.cs
+++ b/src/Utils/Dybal.Utils.Guards/CompactList.cs
@@ -7,7 +7,7 @@ namespace Dybal.Utils.Guards
     /// Custom List implementation that does not make any dynamic allocation if Count <= 3
     /// </summary>
     /// <typeparam name="TElement"></typeparam>
-    public readonly struct CompactList<TElement> : IReadOnlyList<TElement?>
+    internal readonly struct CompactList<TElement> : IReadOnlyList<TElement?>
     {
         private readonly TElement? firstElement = default;
         private readonly TElement? secondElement = default;

--- a/src/Utils/Dybal.Utils.Guards/CompactList.cs
+++ b/src/Utils/Dybal.Utils.Guards/CompactList.cs
@@ -1,0 +1,128 @@
+﻿using System.Collections;
+
+namespace Dybal.Utils.Guards
+{
+    /// <summary>
+    /// Custom List implementation that does not make any dynamic allocation if Count <= 3
+    /// </summary>
+    /// <typeparam name="TElement"></typeparam>
+    public struct CompactList<TElement> : IList<TElement?>
+    {
+        private TElement? firstElement;
+        private TElement? secondElement;
+        private TElement? thirdElement;
+        private List<TElement?>? otherElements;
+        private int count;
+
+        public TElement? this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= count)
+                    ThrowHelper.ThrowArgumentException("Provided index was outside of the valid range.", nameof(index));
+
+                return index switch
+                {
+                    0 => firstElement,
+                    1 => secondElement,
+                    2 => thirdElement,
+                    _ => otherElements![index - 3],
+                };
+            }
+            set
+            {
+                if (index < 0 || index >= count)
+                    ThrowHelper.ThrowArgumentException("Provided index was outside of the valid range.", nameof(index));
+
+                switch (index)
+                {
+                    case 0: firstElement = value; break;
+                    case 1: secondElement = value; break;
+                    case 2: thirdElement = value; break;
+                    default: otherElements![index] = value; break;
+                }
+            }
+        }
+
+        public int Count { get { return count; } set { count = value; } }
+        public bool IsReadOnly => false;
+
+        public void Add(TElement? item)
+        {
+            if (count <= 2)
+            {
+                switch (count)
+                {
+                    case 0: firstElement = item; break;
+                    case 1: secondElement = item; break;
+                    case 2: thirdElement = item; break;
+                }
+            }
+            else
+            {
+                otherElements ??= new List<TElement?>();
+                otherElements.Add(item);
+            }
+
+            count++;
+        }
+
+        public void Clear()
+        {
+            firstElement = default;
+            secondElement = default;
+            thirdElement = default;
+            otherElements?.Clear();
+        }
+
+        public bool Contains(TElement? item)
+        {
+            return IndexOf(item) != -1;
+        }
+
+        public void CopyTo(TElement?[] array, int arrayIndex)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerator<TElement?> GetEnumerator()
+        {
+            for (var index = 0; index < count; index++)
+                yield return this[index];
+        }
+
+        public int IndexOf(TElement? item)
+        {
+            if (item == null)
+                return -1;
+
+            for (var index = 0; index < count; index++)
+            {
+                if (item.Equals(this[index]))
+                    return index;
+            }
+
+            return -1;
+        }
+
+        public void Insert(int index, TElement? item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Remove(TElement? item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveAt(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Utils/Dybal.Utils.Guards/Guard.cs
+++ b/src/Utils/Dybal.Utils.Guards/Guard.cs
@@ -25,7 +25,7 @@ public static class Guard
         var firstArgument = new Argument<object?>(firstValue, firstParamName!);
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
 
-        return Arguments(new CompactList<Argument<object?>>(firstArgument, secondArgument));
+        return Arguments(new CompactList<IArgument<object?>>(firstArgument, secondArgument));
     }
 
     public static MultipleArgumentGuard Arguments<TArgument1, TArgument2, TArgument3>(
@@ -40,10 +40,10 @@ public static class Guard
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
         var thirdArgument = new Argument<object?>(thirdValue, thirdParamName!);
 
-        return Arguments(new CompactList<Argument<object?>>(firstArgument, secondArgument, thirdArgument));
+        return Arguments(new CompactList<IArgument<object?>>(firstArgument, secondArgument, thirdArgument));
     }
 
-    internal static MultipleArgumentGuard Arguments(CompactList<Argument<object?>> arguments)
+    internal static MultipleArgumentGuard Arguments(CompactList<IArgument<object?>> arguments)
     {
         return new MultipleArgumentGuard(arguments, true);
     }

--- a/src/Utils/Dybal.Utils.Guards/Guard.cs
+++ b/src/Utils/Dybal.Utils.Guards/Guard.cs
@@ -25,7 +25,7 @@ public static class Guard
         var firstArgument = new Argument<object?>(firstValue, firstParamName!);
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
 
-        return Arguments(new CompactList<Argument<object?>> { firstArgument, secondArgument });
+        return Arguments(new CompactList<Argument<object?>>(firstArgument, secondArgument));
     }
 
     public static MultipleArgumentGuard Arguments<TArgument1, TArgument2, TArgument3>(
@@ -40,7 +40,7 @@ public static class Guard
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
         var thirdArgument = new Argument<object?>(thirdValue, thirdParamName!);
 
-        return Arguments(new CompactList<Argument<object?>> { firstArgument, secondArgument, thirdArgument });
+        return Arguments(new CompactList<Argument<object?>>(firstArgument, secondArgument, thirdArgument));
     }
 
     internal static MultipleArgumentGuard Arguments(CompactList<Argument<object?>> arguments)

--- a/src/Utils/Dybal.Utils.Guards/Guard.cs
+++ b/src/Utils/Dybal.Utils.Guards/Guard.cs
@@ -25,7 +25,7 @@ public static class Guard
         var firstArgument = new Argument<object?>(firstValue, firstParamName!);
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
 
-        return Arguments(new[] { firstArgument, secondArgument });
+        return Arguments(new CompactList<Argument<object?>> { firstArgument, secondArgument });
     }
 
     public static MultipleArgumentGuard Arguments<TArgument1, TArgument2, TArgument3>(
@@ -40,10 +40,10 @@ public static class Guard
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
         var thirdArgument = new Argument<object?>(thirdValue, thirdParamName!);
 
-        return Arguments(new[] { firstArgument, secondArgument, thirdArgument });
+        return Arguments(new CompactList<Argument<object?>> { firstArgument, secondArgument, thirdArgument });
     }
 
-    internal static MultipleArgumentGuard Arguments(Argument<object?>[] arguments)
+    internal static MultipleArgumentGuard Arguments(CompactList<Argument<object?>> arguments)
     {
         return new MultipleArgumentGuard(arguments, true);
     }

--- a/src/Utils/Dybal.Utils.Guards/Guard.cs
+++ b/src/Utils/Dybal.Utils.Guards/Guard.cs
@@ -13,7 +13,7 @@ public static class Guard
     /// <returns>Instance of ArgumentGuard&lt;TArgument&gt;</returns>
     public static IArgumentGuard<TArgument> Argument<TArgument>(TArgument argumentValue, [CallerArgumentExpression("argumentValue")] string? argumentName = null)
     {
-        return new ArgumentGuard<TArgument>(argumentValue, argumentName!, true);
+        return new ArgumentGuard<TArgument>(new Argument<TArgument>(argumentValue, argumentName!), true);
     }
 
     public static MultipleArgumentGuard Arguments<TArgument1, TArgument2>(

--- a/src/Utils/Dybal.Utils.Guards/GuardProvider.cs
+++ b/src/Utils/Dybal.Utils.Guards/GuardProvider.cs
@@ -33,7 +33,7 @@ public static class GuardProvider
         var firstArgument = new Argument<object?>(firstValue, firstParamName!);
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
 
-        return Guards.Guard.Arguments(new CompactList<Argument<object?>>(firstArgument, secondArgument));
+        return Guards.Guard.Arguments(new CompactList<IArgument<object?>>(firstArgument, secondArgument));
     }
 
     public static MultipleArgumentGuard Guard<TArgument1, TArgument2, TArgument3>(
@@ -48,10 +48,10 @@ public static class GuardProvider
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
         var thirdArgument = new Argument<object?>(thirdValue, thirdParamName!);
 
-        return Guards.Guard.Arguments(new CompactList<Argument<object?>>(firstArgument, secondArgument, thirdArgument));
+        return Guards.Guard.Arguments(new CompactList<IArgument<object?>>(firstArgument, secondArgument, thirdArgument));
     }
 
-    public static MultipleArgumentGuard Guard(params Argument<object?>[] arguments)
+    public static MultipleArgumentGuard Guard(params IArgument<object?>[] arguments)
     {
         return new MultipleArgumentGuard(arguments, true);
     }

--- a/src/Utils/Dybal.Utils.Guards/GuardProvider.cs
+++ b/src/Utils/Dybal.Utils.Guards/GuardProvider.cs
@@ -33,7 +33,7 @@ public static class GuardProvider
         var firstArgument = new Argument<object?>(firstValue, firstParamName!);
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
 
-        return Guard(new CompactList<Argument<object?>>(firstArgument, secondArgument));
+        return Guards.Guard.Arguments(new CompactList<Argument<object?>>(firstArgument, secondArgument));
     }
 
     public static MultipleArgumentGuard Guard<TArgument1, TArgument2, TArgument3>(
@@ -48,11 +48,11 @@ public static class GuardProvider
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
         var thirdArgument = new Argument<object?>(thirdValue, thirdParamName!);
 
-        return Guard(new CompactList<Argument<object?>>(firstArgument, secondArgument, thirdArgument));
+        return Guards.Guard.Arguments(new CompactList<Argument<object?>>(firstArgument, secondArgument, thirdArgument));
     }
 
-    public static MultipleArgumentGuard Guard(CompactList<Argument<object?>> arguments)
+    public static MultipleArgumentGuard Guard(params Argument<object?>[] arguments)
     {
-        return Guards.Guard.Arguments(arguments);
+        return new MultipleArgumentGuard(arguments, true);
     }
 }

--- a/src/Utils/Dybal.Utils.Guards/GuardProvider.cs
+++ b/src/Utils/Dybal.Utils.Guards/GuardProvider.cs
@@ -33,7 +33,7 @@ public static class GuardProvider
         var firstArgument = new Argument<object?>(firstValue, firstParamName!);
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
 
-        return Guard(new[] { firstArgument, secondArgument });
+        return Guard(new CompactList<Argument<object?>>() { firstArgument, secondArgument });
     }
 
     public static MultipleArgumentGuard Guard<TArgument1, TArgument2, TArgument3>(
@@ -48,10 +48,10 @@ public static class GuardProvider
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
         var thirdArgument = new Argument<object?>(thirdValue, thirdParamName!);
 
-        return Guard(new[] { firstArgument, secondArgument, thirdArgument });
+        return Guard(new CompactList<Argument<object?>>() { firstArgument, secondArgument, thirdArgument });
     }
 
-    public static MultipleArgumentGuard Guard(Argument<object?>[] arguments)
+    public static MultipleArgumentGuard Guard(CompactList<Argument<object?>> arguments)
     {
         return Guards.Guard.Arguments(arguments);
     }

--- a/src/Utils/Dybal.Utils.Guards/GuardProvider.cs
+++ b/src/Utils/Dybal.Utils.Guards/GuardProvider.cs
@@ -33,7 +33,7 @@ public static class GuardProvider
         var firstArgument = new Argument<object?>(firstValue, firstParamName!);
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
 
-        return Guard(new CompactList<Argument<object?>>() { firstArgument, secondArgument });
+        return Guard(new CompactList<Argument<object?>>(firstArgument, secondArgument));
     }
 
     public static MultipleArgumentGuard Guard<TArgument1, TArgument2, TArgument3>(
@@ -48,7 +48,7 @@ public static class GuardProvider
         var secondArgument = new Argument<object?>(secondValue, secondParamName!);
         var thirdArgument = new Argument<object?>(thirdValue, thirdParamName!);
 
-        return Guard(new CompactList<Argument<object?>>() { firstArgument, secondArgument, thirdArgument });
+        return Guard(new CompactList<Argument<object?>>(firstArgument, secondArgument, thirdArgument));
     }
 
     public static MultipleArgumentGuard Guard(CompactList<Argument<object?>> arguments)

--- a/src/Utils/Dybal.Utils.Guards/IArgument.cs
+++ b/src/Utils/Dybal.Utils.Guards/IArgument.cs
@@ -1,0 +1,7 @@
+﻿namespace Dybal.Utils.Guards;
+
+public interface IArgument<out TArgument>
+{
+    TArgument Value { get; }
+    string Name { get; }
+}

--- a/src/Utils/Dybal.Utils.Guards/IArgumentGuard.cs
+++ b/src/Utils/Dybal.Utils.Guards/IArgumentGuard.cs
@@ -3,7 +3,7 @@
 public interface IArgumentGuard<out TArgument>
 {
     bool IsActive { get; }
-    TArgument ArgumentValue { get; }
-    string ArgumentName { get; }
+    IArgument<TArgument> Argument { get; }
+
     IConditionalArgumentGuard<TArgument?> If(bool condition);
 }

--- a/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuard.cs
+++ b/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuard.cs
@@ -2,10 +2,10 @@
 
 public record struct MultipleArgumentGuard
 {
-    public Argument<object?>[] Arguments { get; }
+    public CompactList<Argument<object?>> Arguments { get; }
     public bool IsActive { get; private set; }
 
-    internal MultipleArgumentGuard(Argument<object?>[] arguments, bool isActive)
+    internal MultipleArgumentGuard(CompactList<Argument<object?>> arguments, bool isActive)
     {
         Arguments = arguments;
         IsActive = isActive;

--- a/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuard.cs
+++ b/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuard.cs
@@ -2,10 +2,10 @@
 
 public record struct MultipleArgumentGuard
 {
-    public IReadOnlyList<Argument<object?>> Arguments { get; }
+    public IReadOnlyList<IArgument<object?>> Arguments { get; }
     public bool IsActive { get; private set; }
 
-    internal MultipleArgumentGuard(IReadOnlyList<Argument<object?>> arguments, bool isActive)
+    internal MultipleArgumentGuard(IReadOnlyList<IArgument<object?>> arguments, bool isActive)
     {
         Arguments = arguments;
         IsActive = isActive;

--- a/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuard.cs
+++ b/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuard.cs
@@ -2,10 +2,10 @@
 
 public record struct MultipleArgumentGuard
 {
-    public CompactList<Argument<object?>> Arguments { get; }
+    public IReadOnlyList<Argument<object?>> Arguments { get; }
     public bool IsActive { get; private set; }
 
-    internal MultipleArgumentGuard(CompactList<Argument<object?>> arguments, bool isActive)
+    internal MultipleArgumentGuard(IReadOnlyList<Argument<object?>> arguments, bool isActive)
     {
         Arguments = arguments;
         IsActive = isActive;

--- a/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuardExtensions.AtLeastOneIsNotNull.cs
+++ b/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuardExtensions.AtLeastOneIsNotNull.cs
@@ -9,7 +9,7 @@ public static partial class MultipleArgumentGuardExtensions
             if (guard.Arguments.Select(static argument => argument.Value).All(static value => value is null))
             {
                 var argumentNames = string.Join(", ", guard.Arguments.Select(static argument => argument.Name));
-                ThrowHelper.ThrowArgumentException(message ?? $"Some of {argumentNames} must be not null.", argumentNames);
+                ThrowHelper.Throw<ArgumentException>(argumentNames, message ?? $"Some of {argumentNames} must be not null.");
             }
         }
     }

--- a/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuardExtensions.AtLeastOneIsNotNull.cs
+++ b/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuardExtensions.AtLeastOneIsNotNull.cs
@@ -9,7 +9,7 @@ public static partial class MultipleArgumentGuardExtensions
             if (guard.Arguments.Select(static argument => argument.Value).All(static value => value is null))
             {
                 var argumentNames = string.Join(", ", guard.Arguments.Select(static argument => argument.Name));
-                throw new ArgumentException(message ?? $"Some of {argumentNames} must be not null.", argumentNames);
+                ThrowHelper.ThrowArgumentException(message ?? $"Some of {argumentNames} must be not null.", argumentNames);
             }
         }
     }

--- a/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuardExtensions.AtLeastOneIsNotNull.cs
+++ b/src/Utils/Dybal.Utils.Guards/MultipleArgumentGuardExtensions.AtLeastOneIsNotNull.cs
@@ -6,9 +6,9 @@ public static partial class MultipleArgumentGuardExtensions
     {
         if (guard.IsActive)
         {
-            if (guard.Arguments.Select(argument => argument.Value).All(value => value is null))
+            if (guard.Arguments.Select(static argument => argument.Value).All(static value => value is null))
             {
-                var argumentNames = string.Join(", ", guard.Arguments.Select(argument => argument.Name));
+                var argumentNames = string.Join(", ", guard.Arguments.Select(static argument => argument.Name));
                 throw new ArgumentException(message ?? $"Some of {argumentNames} must be not null.", argumentNames);
             }
         }

--- a/src/Utils/Dybal.Utils.Guards/ThrowHelper.cs
+++ b/src/Utils/Dybal.Utils.Guards/ThrowHelper.cs
@@ -1,27 +1,20 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Dybal.Utils.Guards
 {
     internal static class ThrowHelper
     {
         [DoesNotReturn]
-        public static void ThrowArgumentNullException(string paramName)
+        public static void ThrowArgumentNullException(string paramName, string? message = null)
         {
-            throw new ArgumentNullException(paramName);
-        }
-
-        [DoesNotReturn]
-        public static void ThrowArgumentNullException(string paramName, string message)
-        {
+            if (message is null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
             throw new ArgumentNullException(paramName, message);
         }
-
-        [DoesNotReturn]
-        public static void ThrowArgumentException(string message)
-        {
-            throw new ArgumentException(message);
-        }
-
+        
         [DoesNotReturn]
         public static void ThrowArgumentException(string message, string paramName)
         {

--- a/src/Utils/Dybal.Utils.Guards/ThrowHelper.cs
+++ b/src/Utils/Dybal.Utils.Guards/ThrowHelper.cs
@@ -1,0 +1,31 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Dybal.Utils.Guards
+{
+    internal static class ThrowHelper
+    {
+        [DoesNotReturn]
+        public static void ThrowArgumentNullException(string paramName)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowArgumentNullException(string paramName, string message)
+        {
+            throw new ArgumentNullException(paramName, message);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowArgumentException(string message)
+        {
+            throw new ArgumentException(message);
+        }
+
+        [DoesNotReturn]
+        public static void ThrowArgumentException(string message, string paramName)
+        {
+            throw new ArgumentException(message, paramName);
+        }
+    }
+}

--- a/src/Utils/Dybal.Utils.Guards/ThrowHelper.cs
+++ b/src/Utils/Dybal.Utils.Guards/ThrowHelper.cs
@@ -5,20 +5,35 @@ namespace Dybal.Utils.Guards
 {
     internal static class ThrowHelper
     {
+        public delegate TException ExceptionFactory<out TException>(string paramName, string? message = null)
+            where TException : Exception;
+
+        private static readonly Dictionary<Type, ExceptionFactory<Exception>> supportedExceptions = new()
+        {
+            { typeof(ArgumentException), ArgumentExceptionFactory },
+            {typeof(ArgumentNullException), ArgumentNullExceptionFactory }
+        };
+
         [DoesNotReturn]
-        public static void ThrowArgumentNullException(string paramName, string? message = null)
+        public static void Throw<TException>(string paramName, string? message = null)
+            where TException : Exception
+        {
+            var exceptionFactory = supportedExceptions[typeof(TException)];
+            throw exceptionFactory(paramName, message);
+        }
+
+        private static ArgumentException ArgumentExceptionFactory(string paramName, string? message)
+        {
+            return new ArgumentException(message, paramName);
+        }
+
+        private static ArgumentNullException ArgumentNullExceptionFactory(string paramName, string? message)
         {
             if (message is null)
             {
-                throw new ArgumentNullException(paramName);
+                return new ArgumentNullException(paramName);
             }
-            throw new ArgumentNullException(paramName, message);
-        }
-        
-        [DoesNotReturn]
-        public static void ThrowArgumentException(string message, string paramName)
-        {
-            throw new ArgumentException(message, paramName);
+            return new ArgumentNullException(paramName, message);
         }
     }
 }


### PR DESCRIPTION
This is a work-in-progress. Next step would be to replace LINQ on some places with explicit implementation (or more preferrably using existing NuGet packages).

* Changed `Argument` to `record struct`
* Changed lambdas to `static` lambdas
* Added initial `ThrowHelper` and refactored implementation using it
* Added initial `CompactList` and refactored dynamic array allocations using it