### PR TITLE
Added warning when analyzers are not build and fixed packaging

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-            project: ["src/Utils/Dybal.Utils.Guards", "src/Utils/Dybal.Utils.Guards.ObjectExtensions", "src/Analyzers/Dybal.Utils.Guards.Analyzers"]
+            project: ["src/Utils/Dybal.Utils.Guards", "src/Utils/Dybal.Utils.Guards.ObjectExtensions"]
     permissions:
       packages: write
       contents: read
@@ -21,7 +21,7 @@ jobs:
           source-url: https://nuget.pkg.github.com/martindybal/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - run: dotnet build ${{ matrix.project }} --configuration Release
+      - run: dotnet build src/Dybal.Utils.sln --configuration Release
       - name: Create the package
         run: dotnet pack ${{ matrix.project }} --configuration Release
       - name: Push Package to NuGet.org

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-            project: ["src/Utils/Dybal.Utils.Guards", "src/Utils/Dybal.Utils.Guards.ObjectExtensions"]
+            project: ["src/Utils/Dybal.Utils.Guards", "src/Utils/Dybal.Utils.Guards.ObjectExtensions", "src/Analyzers/Dybal.Utils.Guards.Analyzers"]
     permissions:
       packages: write
       contents: read

--- a/src/Utils/Dybal.Utils.Guards.ObjectExtensions/Dybal.Utils.Guards.ObjectExtensions.csproj
+++ b/src/Utils/Dybal.Utils.Guards.ObjectExtensions/Dybal.Utils.Guards.ObjectExtensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<Version>1.0.0-pre-04</Version>
+		<Version>1.0.0-pre-05</Version>
 		<Authors>Martin Dybal</Authors>
 		<PackageProjectUrl>https://github.com/martindybal/Dybal.Utils/tree/main/src/Utils/Dybal.Utils.Guards.ObjectExtensions</PackageProjectUrl>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Utils/Dybal.Utils.Guards/Dybal.Utils.Guards.csproj
+++ b/src/Utils/Dybal.Utils.Guards/Dybal.Utils.Guards.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<Version>1.0.0-pre-04</Version>
@@ -24,7 +24,9 @@
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>
-		<None Include="../../Analyzers/Dybal.Utils.Guards.Analyzers/bin/$(Configuration)/netstandard2.0/*.dll" PackagePath="analyzers/dotnet/cs" Pack="true" Visible="false" />
+		<None 
+			Include="../../Analyzers/Dybal.Utils.Guards.Analyzers/bin/$(Configuration)/netstandard2.0/Dybal.Utils.Guards.Analyzers.dll" 
+			PackagePath="analyzers/dotnet/cs" Pack="true" Visible="false" />
 	</ItemGroup>
 
 </Project>

--- a/src/Utils/Dybal.Utils.Guards/Dybal.Utils.Guards.csproj
+++ b/src/Utils/Dybal.Utils.Guards/Dybal.Utils.Guards.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<Version>1.0.0-pre-04</Version>
+		<Version>1.0.0-pre-05</Version>
 		<Authors>Martin Dybal</Authors>
 		<PackageProjectUrl>https://github.com/martindybal/Dybal.Utils/tree/main/src/Utils/Dybal.Utils.Guards</PackageProjectUrl>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
This PR should fixes an issue with analyzers not being published. There were actually two problems:

1) Analyzers where not built by CI pipeline
2) Due to using wildcard, no errors where produced if the files was not present

Right now, calling `dotnet pack` without the analyzers being built in the same configuration produces the following build errors:
![image](https://user-images.githubusercontent.com/12575176/203557175-83b0a086-f416-47ed-9501-bdb3f90f5681.png)
