### PR TITLE
Made CI builds deterministic

### DIFF
--- a/src/Utils/Directory.Build.props
+++ b/src/Utils/Directory.Build.props
@@ -10,4 +10,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
 	</ItemGroup>
+
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	</PropertyGroup>
 </Project>

--- a/src/Utils/Dybal.Utils.Guards.ObjectExtensions/Dybal.Utils.Guards.ObjectExtensions.csproj
+++ b/src/Utils/Dybal.Utils.Guards.ObjectExtensions/Dybal.Utils.Guards.ObjectExtensions.csproj
@@ -19,10 +19,6 @@
 		<ProjectReference Include="..\Dybal.Utils.Guards\Dybal.Utils.Guards.csproj" />
 	</ItemGroup>
 
-	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<None Include="readme.md">
 			<Pack>True</Pack>

--- a/src/Utils/Dybal.Utils.Guards.ObjectExtensions/Dybal.Utils.Guards.ObjectExtensions.csproj
+++ b/src/Utils/Dybal.Utils.Guards.ObjectExtensions/Dybal.Utils.Guards.ObjectExtensions.csproj
@@ -19,6 +19,10 @@
 		<ProjectReference Include="..\Dybal.Utils.Guards\Dybal.Utils.Guards.csproj" />
 	</ItemGroup>
 
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<None Include="readme.md">
 			<Pack>True</Pack>

--- a/src/Utils/Dybal.Utils.Guards/Dybal.Utils.Guards.csproj
+++ b/src/Utils/Dybal.Utils.Guards/Dybal.Utils.Guards.csproj
@@ -18,7 +18,11 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
-	
+
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<None Include="readme.md">
 			<Pack>True</Pack>

--- a/src/Utils/Dybal.Utils.Guards/Dybal.Utils.Guards.csproj
+++ b/src/Utils/Dybal.Utils.Guards/Dybal.Utils.Guards.csproj
@@ -19,10 +19,6 @@
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 
-	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<None Include="readme.md">
 			<Pack>True</Pack>


### PR DESCRIPTION
This PR should make CI packages deterministic. It is also recommended when using source linking. However, it is (or at least was) very badly documented. See this for more information about the setting: https://github.com/clairernovotny/DeterministicBuilds

After I tested the property I finally received a nice report by NuGet explorer 😄 
![image](https://user-images.githubusercontent.com/12575176/203560281-c521d68a-58b6-47e9-883c-dab0b897ba63.png)
