### PR TITLE
Add InRange guard with inclusive and exclusive checks

### DIFF
--- a/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/InRangeTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/InRangeTests.cs
@@ -1,0 +1,98 @@
+using Dybal.Utils.Guards;
+using Xunit;
+
+namespace Tests.Dybal.Utils.Guards.ArgumentGuard;
+
+public class InRangeTests : UnitTestsBase
+{
+    [Fact]
+    public void NotThrow_When_value_is_equal_to_min_and_inclusive()
+    {
+        // Arrange
+        int value = 1;
+
+        // Act
+        int guardValue = Guard.Argument(value).InRange(1, 10);
+
+        // Assert
+        Assert.Equal(value, guardValue);
+    }
+
+    [Fact]
+    public void NotThrow_When_value_is_equal_to_max_and_inclusive()
+    {
+        // Arrange
+        int value = 10;
+
+        // Act
+        int guardValue = Guard.Argument(value).InRange(1, 10);
+
+        // Assert
+        Assert.Equal(value, guardValue);
+    }
+
+    [Fact]
+    public void Throw_ArgumentOutOfRangeException_When_value_is_less_than_min_inclusive()
+    {
+        // Arrange
+        int value = 0;
+
+        // Act
+        void Act()
+        {
+            value = Guard.Argument(value).InRange(1, 10);
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(Act);
+        Assert.Equal("Value of parameter 'value' (0) must be in the range [1, 10]. (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void NotThrow_When_value_is_between_min_and_max_and_exclusive()
+    {
+        // Arrange
+        int value = 5;
+
+        // Act
+        int guardValue = Guard.Argument(value).InRange(1, 10, inclusive: false);
+
+        // Assert
+        Assert.Equal(value, guardValue);
+    }
+
+    [Fact]
+    public void Throw_ArgumentOutOfRangeException_When_value_is_equal_to_min_and_exclusive()
+    {
+        // Arrange
+        int value = 1;
+
+        // Act
+        void Act()
+        {
+            value = Guard.Argument(value).InRange(1, 10, inclusive: false);
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(Act);
+        Assert.Equal("Value of parameter 'value' (1) must be in the range (1, 10). (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_ArgumentOutOfRangeException_When_value_is_equal_to_max_and_exclusive()
+    {
+        // Arrange
+        int value = 10;
+
+        // Act
+        void Act()
+        {
+            value = Guard.Argument(value).InRange(1, 10, inclusive: false);
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(Act);
+        Assert.Equal("Value of parameter 'value' (10) must be in the range (1, 10). (Parameter 'value')", ex.Message);
+    }
+}
+

--- a/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/InRangeTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/InRangeTests.cs
@@ -94,5 +94,23 @@ public class InRangeTests : UnitTestsBase
         var ex = Assert.Throws<ArgumentOutOfRangeException>(Act);
         Assert.Equal("Value of parameter 'value' (10) must be in the range (1, 10). (Parameter 'value')", ex.Message);
     }
+
+    [Fact]
+    public void Throw_ArgumentOutOfRangeException_with_custom_message_When_was_used()
+    {
+        // Arrange
+        int value = 0;
+        var customMessage = "Custom message.";
+
+        // Act
+        void Act()
+        {
+            value = Guard.Argument(value).InRange(1, 10, message: customMessage);
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(Act);
+        Assert.Equal($"{customMessage} (Parameter 'value')", ex.Message);
+    }
 }
 

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.InRange.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.InRange.cs
@@ -2,7 +2,7 @@ namespace Dybal.Utils.Guards;
 
 public static partial class ArgumentGuardExtensions
 {
-    public static ArgumentGuard<T> InRange<T>(this ArgumentGuard<T> guard, T min, T max, bool inclusive = true)
+    public static ArgumentGuard<T> InRange<T>(this ArgumentGuard<T> guard, T min, T max, bool inclusive = true, string? message = null)
         where T : IComparable<T>
     {
         var value = guard.Argument.Value;
@@ -14,7 +14,7 @@ public static partial class ArgumentGuardExtensions
         {
             var rangeRepresentation = inclusive ? $"[{min}, {max}]" : $"({min}, {max})";
             var defaultMessage = $"Value of parameter '{guard.Argument.Name}' ({value}) must be in the range {rangeRepresentation}.";
-            ThrowHelper.Throw<ArgumentOutOfRangeException>(guard, defaultMessage);
+            ThrowHelper.Throw<ArgumentOutOfRangeException>(guard, message ?? defaultMessage);
         }
 
         return guard;

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.InRange.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.InRange.cs
@@ -1,0 +1,23 @@
+namespace Dybal.Utils.Guards;
+
+public static partial class ArgumentGuardExtensions
+{
+    public static ArgumentGuard<T> InRange<T>(this ArgumentGuard<T> guard, T min, T max, bool inclusive = true)
+        where T : IComparable<T>
+    {
+        var value = guard.Argument.Value;
+        var isInRange = inclusive
+            ? value.CompareTo(min) >= 0 && value.CompareTo(max) <= 0
+            : value.CompareTo(min) > 0 && value.CompareTo(max) < 0;
+
+        if (!isInRange)
+        {
+            var rangeRepresentation = inclusive ? $"[{min}, {max}]" : $"({min}, {max})";
+            var defaultMessage = $"Value of parameter '{guard.Argument.Name}' ({value}) must be in the range {rangeRepresentation}.";
+            ThrowHelper.Throw<ArgumentOutOfRangeException>(guard, defaultMessage);
+        }
+
+        return guard;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ArgumentGuard.InRange extension to validate ranges with optional inclusivity
- test inclusive boundaries and exclusive range failures

## Testing
- `dotnet test src/Dybal.Utils.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b2675d0c8c8329904d1d812f3daadd