### PR TITLE
Add regex pattern match guard

### DIFF
--- a/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/MatchesPatternTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/MatchesPatternTests.cs
@@ -1,0 +1,86 @@
+using System.Text.RegularExpressions;
+using Dybal.Utils.Guards;
+using Xunit;
+
+namespace Tests.Dybal.Utils.Guards.ArgumentGuard;
+
+public class MatchesPatternTests : UnitTestsBase
+{
+    [Fact]
+    public void NotThrow_When_value_matches_pattern()
+    {
+        var value = "abc";
+
+        var actualValue = Guard.Argument(value).MatchesPattern("^abc$");
+
+        Assert.Equal(value, actualValue);
+    }
+
+    [Theory]
+    [InlineData("ABC")]
+    [InlineData("Abc")]
+    [InlineData("aBC")]
+    public void NotThrow_When_value_matches_pattern_ignore_case(string value)
+    {
+        var actualValue = Guard.Argument(value).MatchesPattern("^abc$", RegexOptions.IgnoreCase);
+
+        Assert.Equal(value, actualValue);
+    }
+
+    [Theory]
+    [InlineData("abd")]
+    [InlineData("ab")]
+    [InlineData("abcd")]
+    public void Throw_ArgumentException_When_value_does_not_match_pattern(string value)
+    {
+        void Act()
+        {
+            Guard.Argument(value).MatchesPattern("^abc$");
+        }
+
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal($"\"{value}\" has to match pattern \"^abc$\". (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_with_custom_message_When_value_does_not_match_pattern()
+    {
+        var value = "abd";
+        var customMessage = "Custom message.";
+
+        void Act()
+        {
+            Guard.Argument(value).MatchesPattern("^abc$", message: customMessage);
+        }
+
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal($"{customMessage} (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_CustomException_When_Throws_was_used_and_value_does_not_match_pattern()
+    {
+        var value = "abd";
+
+        void Act()
+        {
+            ThrowHelper.TryRegister((paramName, message) => new CustomException(paramName, message));
+            Guard.Argument(value).Throws<CustomException>().MatchesPattern("^abc$");
+        }
+
+        var customException = Assert.Throws<CustomException>(Act);
+        Assert.Equal("value", customException.ParamName);
+        Assert.Equal("\"abd\" has to match pattern \"^abc$\".", customException.Message);
+    }
+
+    class CustomException : Exception
+    {
+        public string ParamName { get; }
+
+        public CustomException(string paramName, string? message)
+            : base(message)
+        {
+            ParamName = paramName;
+        }
+    }
+}

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.MatchesPattern.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.MatchesPattern.cs
@@ -1,0 +1,17 @@
+using System.Text.RegularExpressions;
+
+namespace Dybal.Utils.Guards;
+
+public static partial class ArgumentGuardExtensions
+{
+    public static ArgumentGuard<string> MatchesPattern(this ArgumentGuard<string> guard, string pattern, RegexOptions options = RegexOptions.None, string? message = null)
+    {
+        if (!Regex.IsMatch(guard.Argument.Value, pattern, options))
+        {
+            message ??= $"\"{guard.Argument.Value}\" has to match pattern \"{pattern}\".";
+            ThrowHelper.Throw<ArgumentException>(guard, message);
+        }
+
+        return guard;
+    }
+}


### PR DESCRIPTION
## Summary
- add MatchesPattern guard extension for regex pattern matching
- cover pattern matching, case-insensitive, and failure scenarios in tests
- verify custom messages and custom exceptions when pattern mismatches

## Testing
- `dotnet test src/Tests/Tests.Dybal.Utils.Guards/Tests.Dybal.Utils.Guards.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b2675b60b0832993e958a7c073a5a4