### PR TITLE
feat: add enum defined guard

### DIFF
--- a/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/EnumDefinedTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/EnumDefinedTests.cs
@@ -1,0 +1,89 @@
+using Dybal.Utils.Guards;
+using Xunit;
+
+namespace Tests.Dybal.Utils.Guards.ArgumentGuard;
+
+public class EnumDefinedTests : UnitTestsBase
+{
+    private enum SampleEnum
+    {
+        First = 1,
+        Second = 2,
+    }
+
+    [Fact]
+    public void NotThrow_When_value_is_defined()
+    {
+        // Arrange
+        SampleEnum value = SampleEnum.First;
+
+        // Act
+        SampleEnum guardValue = Guard.Argument(value).EnumDefined();
+
+        // Assert
+        Assert.Equal(value, guardValue);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_When_value_is_not_defined()
+    {
+        // Arrange
+        SampleEnum value = (SampleEnum)0;
+
+        void Act()
+        {
+            value = Guard.Argument(value).EnumDefined();
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal("Value of parameter 'value' (0) must be defined in enum 'SampleEnum'. (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_with_custom_message_When_was_used()
+    {
+        // Arrange
+        SampleEnum value = (SampleEnum)0;
+        var customMessage = "Custom message.";
+
+        void Act()
+        {
+            value = Guard.Argument(value).EnumDefined(customMessage);
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal($"{customMessage} (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_CustomException_When_Throws_was_used()
+    {
+        // Arrange
+        SampleEnum value = (SampleEnum)0;
+        var customMessage = "Custom message.";
+
+        void Act()
+        {
+            ThrowHelper.TryRegister((paramName, message) => new CustomException(paramName, message));
+            value = Guard.Argument(value).Throws<CustomException>().EnumDefined(customMessage);
+        }
+
+        // Assert
+        var ex = Assert.Throws<CustomException>(Act);
+        Assert.Equal(customMessage, ex.Message);
+        Assert.Equal(nameof(value), ex.ParamName);
+    }
+
+    class CustomException : Exception
+    {
+        public string ParamName { get; }
+
+        public CustomException(string paramName, string? message)
+            : base(message)
+        {
+            ParamName = paramName;
+        }
+    }
+}

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.EnumDefined.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.EnumDefined.cs
@@ -1,0 +1,16 @@
+namespace Dybal.Utils.Guards;
+
+public static partial class ArgumentGuardExtensions
+{
+    public static ArgumentGuard<TEnum> EnumDefined<TEnum>(this ArgumentGuard<TEnum> guard, string? message = null)
+        where TEnum : struct, Enum
+    {
+        if (!Enum.IsDefined(guard.Argument.Value))
+        {
+            message ??= $"Value of parameter '{guard.Argument.Name}' ({guard.Argument.Value}) must be defined in enum '{typeof(TEnum).Name}'.";
+            ThrowHelper.Throw<ArgumentException>(guard, message);
+        }
+
+        return guard;
+    }
+}


### PR DESCRIPTION
## Summary
- add EnumDefined guard extension using Enum.IsDefined to validate enum values
- cover EnumDefined with unit tests for defined and undefined values

## Testing
- `dotnet test src/Dybal.Utils.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b2676145188329b8908c73e547343c