### PR TITLE
Add bool state argument guards

### DIFF
--- a/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/FalseTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/FalseTests.cs
@@ -1,0 +1,156 @@
+using Dybal.Utils.Guards;
+using Xunit;
+
+namespace Tests.Dybal.Utils.Guards.ArgumentGuard;
+
+public class FalseTests : UnitTestsBase
+{
+    [Fact]
+    public void NotThrow_When_false()
+    {
+        // Arrange
+        var value = false;
+
+        // Act
+        var actual = Guard.Argument(value).False();
+
+        // Assert
+        Assert.False(actual);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_When_true()
+    {
+        // Arrange
+        var value = true;
+
+        void Act()
+        {
+            Guard.Argument(value).False();
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal("Value must be false. (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_with_custom_message_When_true()
+    {
+        // Arrange
+        var value = true;
+        var customMessage = "Custom message.";
+
+        void Act()
+        {
+            Guard.Argument(value).False(customMessage);
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal($"{customMessage} (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void NotThrow_When_nullable_false()
+    {
+        // Arrange
+        bool? value = false;
+
+        // Act
+        var actual = Guard.Argument(value).False();
+
+        // Assert
+        Assert.False(actual);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_When_nullable_true()
+    {
+        // Arrange
+        bool? value = true;
+
+        void Act()
+        {
+            Guard.Argument(value).False();
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal("Value must be false. (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_When_null()
+    {
+        // Arrange
+        bool? value = null;
+
+        void Act()
+        {
+            Guard.Argument(value).False();
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal("Value must be false. (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_with_custom_message_When_nullable_true()
+    {
+        // Arrange
+        bool? value = true;
+        var customMessage = "Custom message.";
+
+        void Act()
+        {
+            Guard.Argument(value).False(customMessage);
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal($"{customMessage} (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_CustomException_When_Throws_was_used()
+    {
+        // Arrange
+        var value = true;
+
+        void Act()
+        {
+            ThrowHelper.TryRegister((paramName, message) => new CustomException(paramName, message));
+            Guard.Argument(value).Throws<CustomException>().False();
+        }
+
+        // Assert
+        var ex = Assert.Throws<CustomException>(Act);
+        Assert.Equal(nameof(value), ex.ParamName);
+        Assert.Equal("Value must be false.", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_CustomException_When_nullable_Throws_was_used()
+    {
+        // Arrange
+        bool? value = true;
+
+        void Act()
+        {
+            ThrowHelper.TryRegister((paramName, message) => new CustomException(paramName, message));
+            Guard.Argument(value).Throws<CustomException>().False();
+        }
+
+        // Assert
+        var ex = Assert.Throws<CustomException>(Act);
+        Assert.Equal(nameof(value), ex.ParamName);
+        Assert.Equal("Value must be false.", ex.Message);
+    }
+
+    class CustomException(string paramName, string? message) : Exception(message)
+    {
+        public string ParamName { get; } = paramName;
+    }
+}

--- a/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/TrueTests.cs
+++ b/src/Tests/Tests.Dybal.Utils.Guards/ArgumentGuard/TrueTests.cs
@@ -1,0 +1,156 @@
+using Dybal.Utils.Guards;
+using Xunit;
+
+namespace Tests.Dybal.Utils.Guards.ArgumentGuard;
+
+public class TrueTests : UnitTestsBase
+{
+    [Fact]
+    public void NotThrow_When_true()
+    {
+        // Arrange
+        var value = true;
+
+        // Act
+        var actual = Guard.Argument(value).True();
+
+        // Assert
+        Assert.True(actual);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_When_false()
+    {
+        // Arrange
+        var value = false;
+
+        void Act()
+        {
+            Guard.Argument(value).True();
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal("Value must be true. (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_with_custom_message_When_false()
+    {
+        // Arrange
+        var value = false;
+        var customMessage = "Custom message.";
+
+        void Act()
+        {
+            Guard.Argument(value).True(customMessage);
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal($"{customMessage} (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void NotThrow_When_nullable_true()
+    {
+        // Arrange
+        bool? value = true;
+
+        // Act
+        var actual = Guard.Argument(value).True();
+
+        // Assert
+        Assert.True(actual);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_When_nullable_false()
+    {
+        // Arrange
+        bool? value = false;
+
+        void Act()
+        {
+            Guard.Argument(value).True();
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal("Value must be true. (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_When_null()
+    {
+        // Arrange
+        bool? value = null;
+
+        void Act()
+        {
+            Guard.Argument(value).True();
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal("Value must be true. (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_ArgumentException_with_custom_message_When_nullable_false()
+    {
+        // Arrange
+        bool? value = false;
+        var customMessage = "Custom message.";
+
+        void Act()
+        {
+            Guard.Argument(value).True(customMessage);
+        }
+
+        // Assert
+        var ex = Assert.Throws<ArgumentException>(Act);
+        Assert.Equal($"{customMessage} (Parameter 'value')", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_CustomException_When_Throws_was_used()
+    {
+        // Arrange
+        var value = false;
+
+        void Act()
+        {
+            ThrowHelper.TryRegister((paramName, message) => new CustomException(paramName, message));
+            Guard.Argument(value).Throws<CustomException>().True();
+        }
+
+        // Assert
+        var ex = Assert.Throws<CustomException>(Act);
+        Assert.Equal(nameof(value), ex.ParamName);
+        Assert.Equal("Value must be true.", ex.Message);
+    }
+
+    [Fact]
+    public void Throw_CustomException_When_nullable_Throws_was_used()
+    {
+        // Arrange
+        bool? value = false;
+
+        void Act()
+        {
+            ThrowHelper.TryRegister((paramName, message) => new CustomException(paramName, message));
+            Guard.Argument(value).Throws<CustomException>().True();
+        }
+
+        // Assert
+        var ex = Assert.Throws<CustomException>(Act);
+        Assert.Equal(nameof(value), ex.ParamName);
+        Assert.Equal("Value must be true.", ex.Message);
+    }
+
+    class CustomException(string paramName, string? message) : Exception(message)
+    {
+        public string ParamName { get; } = paramName;
+    }
+}

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.False.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.False.cs
@@ -1,0 +1,24 @@
+namespace Dybal.Utils.Guards;
+
+public static partial class ArgumentGuardExtensions
+{
+    public static ArgumentGuard<bool> False(this ArgumentGuard<bool> guard, string? message = null)
+    {
+        if (guard.Argument.Value)
+        {
+            ThrowHelper.Throw<ArgumentException>(guard, message ?? "Value must be false.");
+        }
+
+        return guard;
+    }
+
+    public static ArgumentGuard<bool> False(this ArgumentGuard<bool?> guard, string? message = null)
+    {
+        if (guard.Argument.Value != false)
+        {
+            ThrowHelper.Throw<ArgumentException>(guard, message ?? "Value must be false.");
+        }
+
+        return ArgumentGuard<bool>.From(guard, new Argument<bool>(guard.Argument.Value.Value, guard.Argument.Name));
+    }
+}

--- a/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.True.cs
+++ b/src/Utils/Dybal.Utils.Guards/ArgumentGuardExtensions.True.cs
@@ -1,0 +1,24 @@
+namespace Dybal.Utils.Guards;
+
+public static partial class ArgumentGuardExtensions
+{
+    public static ArgumentGuard<bool> True(this ArgumentGuard<bool> guard, string? message = null)
+    {
+        if (!guard.Argument.Value)
+        {
+            ThrowHelper.Throw<ArgumentException>(guard, message ?? "Value must be true.");
+        }
+
+        return guard;
+    }
+
+    public static ArgumentGuard<bool> True(this ArgumentGuard<bool?> guard, string? message = null)
+    {
+        if (guard.Argument.Value != true)
+        {
+            ThrowHelper.Throw<ArgumentException>(guard, message ?? "Value must be true.");
+        }
+
+        return ArgumentGuard<bool>.From(guard, new Argument<bool>(guard.Argument.Value.Value, guard.Argument.Name));
+    }
+}


### PR DESCRIPTION
## Summary
- add True and False guards for ArgumentGuard<bool> and ArgumentGuard<bool?>
- streamline guard implementations by removing unnecessary XML comments
- cover success and failure scenarios with comprehensive unit tests

## Testing
- `dotnet test src/Dybal.Utils.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b2675f62548329b2fc09902ff1a704